### PR TITLE
Abort on bad websites

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,10 +68,6 @@ function generateReport(xml) {
 
 }
 
-function checkUrl(url) {
-
-}
-
 function validate(opts, cb) {
   opts = opts || {};
   cb = cb || function() {};

--- a/lib/checkURI.js
+++ b/lib/checkURI.js
@@ -1,0 +1,12 @@
+var protocolify = require('protocolify'),
+    http = require('http-https');
+
+function check(options, callback) {
+  http.get(protocolify(options.qs.uri), function() {
+    callback(null, null);
+  }).on('error', function(e) {
+    return callback('Unable to connect to ' + e.hostname, null);
+  });
+}
+
+module.exports = check;

--- a/lib/getAcheckerResults.js
+++ b/lib/getAcheckerResults.js
@@ -1,3 +1,8 @@
+var http = require('http'),
+    querystring = require('querystring'),
+    async = require('async'),
+    checkURI = require('./checkURI');
+
 function getAcheckerResults(options, callback) {
   if (!options) {
     return callback(new Error('Missing required input options'));
@@ -8,25 +13,31 @@ function getAcheckerResults(options, callback) {
   if (!options.qs) {
     return callback(new Error('Missing required input options'));
   }
-  var http = require('http');
-  var querystring = require('querystring');
   var body = '';
   var apiUrl = options.uri + '?';
   var url = apiUrl + querystring.stringify(options.qs);
 
-  http.get(url, function(response) {
-
-    response.on('data', function(chunk) {
-      body += chunk.toString();
-    });
-
-    response.on('end', function() {
-      return callback(null, body);
-    });
-
-  }).on('error', function(error) {
-    return callback(error, null);
-  });
+  async.parallel([
+      function(cb) {
+        checkURI(options, cb);
+      },
+      function(callback) {
+        http.get(url, function(response) {
+          response.on('data', function(chunk) {
+            body += chunk.toString();
+          });
+          response.on('end', function() {
+            return callback(null, body);
+          });
+        }).on('error', function(error) {
+          return callback(error, null);
+        });
+      }
+    ],
+    function finished(err, results) {
+      return callback(err, results[1]);
+    }
+  );
 
 }
 

--- a/package.json
+++ b/package.json
@@ -48,8 +48,10 @@
     "coveralls": "jscoverage index.js && WCAG_COVERAGE=1 nodeunit --reporter=lcov test | coveralls"
   },
   "dependencies": {
+    "async": "^1.3.0",
     "capitalize": "^0.5.0",
     "html-entities": "^1.1.2",
+    "http-https": "^1.0.0",
     "indent-string": "^1.2.1",
     "localtunnel": "^1.5.0",
     "log-symbols": "^1.0.2",

--- a/test/getAcheckerResults-test.js
+++ b/test/getAcheckerResults-test.js
@@ -21,5 +21,33 @@ exports.getAcheckerResults = {
       test.throws(err);
       test.done();
     });
+  },
+  'Abort if provided URI is unreachable': function (test) {
+    opts = {
+      uri: 'http://achecker.ca/checkacc.php',
+      qs: {
+        uri: 'thisisnotarealwebsite.foobar',
+        output: 'rest',
+        guide: 'WCAG2-AA'
+      }
+    };
+    getAcheckerResults(opts, function(err, results) {
+      test.ok(err, 'The URI was successfully reached.');
+      test.done();
+    });
+  },
+  'Allow HTTPS URIs': function (test) {
+    opts = {
+      uri: 'http://achecker.ca/checkacc.php',
+      qs: {
+        uri: 'https://wikipedia.org',
+        output: 'rest',
+        guide: 'WCAG2-AA'
+      }
+    };
+    getAcheckerResults(opts, function(err, results) {
+      test.ok(err === null);
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
AChecker's API reports a status of `PASS` if the URL provided by the user isn't valid ([example](http://achecker.ca/checkacc.php?uri=http://blahblahbadwebsite.foo&id=69f6ea6a9e30b37c3d341d3b716df218f8942c0e&output=rest)). This is bad.

This PR connects to AChecker while simultaneously attempting to reach the URL via http. It uses `async.parallel` to avoid a race condition. If the http request fails, it aborts and notifies the user.

Fixes #11. 
