### PR TITLE
Updates dependencies and removes use strict from test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wcag",
   "description": "Test a site for WCAG or Section 508 compliancy.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "homepage": "https://github.com/cfpb/node-wcag",
   "author": {
     "name": "Chris Contolini",
@@ -49,18 +49,18 @@
   },
   "dependencies": {
     "async": "^1.3.0",
-    "capitalize": "^0.5.0",
+    "capitalize": "^1.0.0",
     "html-entities": "^1.1.2",
     "http-https": "^1.0.0",
     "indent-string": "^1.2.1",
-    "localtunnel": "^1.5.0",
+    "localtunnel": "^1.5.1",
     "log-symbols": "^1.0.2",
-    "minimist": "~0.0.8",
-    "protocolify": "^1.0.0",
-    "update-notifier": "^0.4.0",
+    "minimist": "^1.1.1",
+    "protocolify": "^1.0.1",
+    "update-notifier": "^0.5.0",
     "valid-url": "^1.0.9",
-    "verbalize": "~0.1.1",
-    "xml2json": "^0.6.1"
+    "verbalize": "^0.1.2",
+    "xml2json": "^0.7.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/test/wcag-tests.js
+++ b/test/wcag-tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var wcag = process.env.WCAG_COVERAGE ? require('../index-cov.js') : require('../index.js');
 
 /*


### PR DESCRIPTION
Removes 'use strict' from wcag-test.js and updates the following dependencies:

captalize 0.5.0 -> 1.0.0
localtunnel 1.5.0 -> 1.5.1
minimist 0.8.0 -> 1.1.1
protocolify 1.0.0 -> 1.0.1
update-notifier 0.4.0 -> 0.5.0
verbalize 0.1.1 -> 0.1.2
xml2json 0.6.1 -> 0.7.1
