### PR TITLE
Fix Travis CI by updating dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,11 +16,6 @@ rules:
 
   # Rules for flagging POSSIBLE ERRORS.
 
-  # Consistent use of trailing commas in object and array literals.
-  # This rule is needed for IE8- support.
-  comma-dangle:
-    - never
-
   # Disallows assignment in conditional expressions.
   no-cond-assign:
     - 2
@@ -45,7 +40,7 @@ rules:
   no-empty: 2
 
   # Disallows use of empty character classes in regular expressions.
-  no-empty-class: 2
+  no-empty-character-class: 2
 
   # Disallows assigning to the exception in a catch block.
   no-ex-assign: 2
@@ -84,7 +79,7 @@ rules:
 
   # Disallows reserved words being used as object literal keys.
   # Unneeded in ECMAScript 5+ environments.
-  no-reserved-keys: 2
+  quote-props: 2
 
   # Disallows sparse arrays.
   # Array values should be explicitly defined.
@@ -372,7 +367,7 @@ rules:
     - 2
     - 2
     -
-      indentSwitchCase: false
+      VariableDeclarator: 2
 
   # Enforce one true brace style.
   brace-style:
@@ -480,7 +475,7 @@ rules:
   no-underscore-dangle: 0
 
   # Disallows wrapping of non-IIFE statements in parens.
-  no-wrap-func: 2
+  spaced-comment: 2
 
   # Disallows multiple var statements per function.
   one-var: 0
@@ -562,7 +557,7 @@ rules:
       nonwords: false
 
   # Requires a space immediately following the // in a line comment.
-  spaced-line-comment:
+  spaced-comment:
     - 2
     - always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - '0.12'
 install:
-  - npm install -g nodeunit eslint
   - npm install
 after_script:
   - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     "coveralls": "jscoverage index.js && WCAG_COVERAGE=1 nodeunit --reporter=lcov test | coveralls"
   },
   "dependencies": {
-    "async": "^1.3.0",
+    "async": "^1.4.2",
     "capitalize": "^1.0.0",
-    "html-entities": "^1.1.2",
+    "html-entities": "^1.1.3",
     "http-https": "^1.0.0",
-    "indent-string": "^1.2.1",
-    "localtunnel": "^1.5.1",
+    "indent-string": "^2.1.0",
+    "localtunnel": "^1.7.0",
     "log-symbols": "^1.0.2",
-    "minimist": "^1.1.1",
+    "minimist": "^1.2.0",
     "protocolify": "^1.0.1",
     "update-notifier": "^0.5.0",
     "valid-url": "^1.0.9",
@@ -58,10 +58,10 @@
     "xml2js": "^0.4.12"
   },
   "devDependencies": {
-    "coveralls": "^2.11.2",
-    "eslint": "^0.21.2",
-    "jscoverage": "^0.5.9",
+    "coveralls": "^2.11.4",
+    "eslint": "^1.4.3",
+    "jscoverage": "^0.6.0",
     "nodeunit": "^0.9.1",
-    "verb": "~0.2.0"
+    "verb": "~0.8.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wcag",
   "description": "Test a site for WCAG or Section 508 compliancy.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/cfpb/node-wcag",
   "author": {
     "name": "Chris Contolini",


### PR DESCRIPTION
Turns out the issue with #31 was an outdated version of `verb` that was trying to install a [module](https://registry.npmjs.org/repo-templates) that was recently unpublished from npm. This PR updates verb and all other dependencies. The `.eslintrc` file was also updated in order to be compatible with the latest version of ESLint.
