### PR TITLE
Include url path in tunnel url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,41 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 0.2.1 - 2015-09-17
+
+### Fixed
+- Added support for paths when checking URLs locally.
+
+
+## 0.2.0 - 2015-09-16
+
+### Changed
+- Removes xml2json and implements xml2js.
+
+
+## 0.1.11 - 2015-07-17
+
+
+## 0.1.9 - 2015-07-02
+
+
+## 0.1.8 - 2015-06-30
+
+
+## 0.1.7 - 2015-06-11
+
+
+## 0.1.6 - 2015-05-28
+
+
+## 0.1.3 - 2015-05-01
+
+
+## 0.1.2 - 2015-05-01
+
+
+## 0.1.1 - 2015-04-30
+
 
 ## 0.1.0 - 2015-04-30
 

--- a/cli.js
+++ b/cli.js
@@ -64,7 +64,7 @@ if (isLocal) {
       log.error(err);
       process.exit(1);
     }
-    validate(tunnel.url, function() {
+    validate(tunnel.url + url.parse( uri ).pathname, function() {
       tunnel.close();
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wcag",
   "description": "Test a site for WCAG or Section 508 compliancy.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/cfpb/node-wcag",
   "author": {
     "name": "Chris Contolini",


### PR DESCRIPTION
Fixes https://github.com/cfpb/node-wcag/issues/35
Fixes https://github.com/cfpb/node-wcag/issues/37
## Changes
- Added support for paths when checking URLs locally.
## Testing
- `wcag localhost:8000 --id=<achecker id>` and `wcag localhost:8000/a/sub/path --id=<achecker id>` should check different pages.
## Review
- @contolini 
- @zrrrzzt 
